### PR TITLE
sbt 1.0 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization := "com.joescii"
 
 homepage := Some(url("https://github.com/joescii/sbt-js-test"))
 
-version := "0.2.0"
+version := "0.3.0"
 
 val htmlunitVersion = settingKey[String]("Version of htmlunit")
 htmlunitVersion := "2.19"
@@ -22,7 +22,7 @@ libraryDependencies ++= Seq(
   "net.sourceforge.htmlunit"  %  "htmlunit"             % htmlunitVersion.value       % "compile",
   "org.webjars"               %  "webjars-locator-core" % webjarLocatorVersion.value  % "compile",
   "org.webjars.bower"         %  "jasmine"              % jasmineVersion.value        % "provided",
-  "org.scalatest"             %% "scalatest"            % "2.2.6"                     % "test,it"
+  "org.scalatest"             %% "scalatest"            % "3.0.5"                     % "test,it"
 )
 
 // don't bother publishing javadoc
@@ -30,14 +30,13 @@ publishArtifact in (Compile, packageDoc) := false
 
 sbtVersion in Global := {
   scalaBinaryVersion.value match {
-    case "2.10" => "0.13.11"
-//    case "2.9.2" => "0.12.4"
+    case "2.12" => "1.2.8"
   }
 }
 
-scalaVersion in Global := "2.10.5"
+scalaVersion in Global := "2.12.8"
 
-crossScalaVersions := Seq("2.10.5")
+crossScalaVersions := Seq("2.12.8")
 
 scalacOptions ++= Seq("-unchecked", "-deprecation")
 
@@ -69,10 +68,10 @@ copyJarForTests := {
 
   dst
 }
-copyJarForTests <<= copyJarForTests.dependsOn(Keys.`package` in Compile)
+copyJarForTests := (copyJarForTests.dependsOn(Keys.`package` in Compile)).value
 
-(test in IntegrationTest) <<= (test in IntegrationTest).dependsOn(copyJarForTests)
-(testOnly in IntegrationTest) <<= (testOnly in IntegrationTest).dependsOn(copyJarForTests)
+(test in IntegrationTest) := ((test in IntegrationTest).dependsOn(copyJarForTests)).value
+(testOnly in IntegrationTest) := ((testOnly in IntegrationTest).dependsOn(copyJarForTests)).evaluated
 
 buildInfoKeys := Seq[BuildInfoKey](
   version,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.5.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M12")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M13-4")

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M12")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M13-4")

--- a/src/it/scala/com/joescii/sbtjs/AllPassSpec.scala
+++ b/src/it/scala/com/joescii/sbtjs/AllPassSpec.scala
@@ -23,7 +23,7 @@ class AllPassSpec extends SbtJsTestSpec("allPass") {
     }
 
     "announce that 1 spec ran with 0 failures" in {
-      result.futureValue._2.reverse.apply(1) shouldEqual "[info] 1 spec, 0 failures"
+      result.futureValue._2.reverse.apply(3) shouldEqual "[info] 1 spec, 0 failures"
     }
 
     "announce that the task was successful" in {

--- a/src/it/scala/com/joescii/sbtjs/BigSuiteSpec.scala
+++ b/src/it/scala/com/joescii/sbtjs/BigSuiteSpec.scala
@@ -8,7 +8,7 @@ class BigSuiteSpec extends SbtJsTestSpec("bigSuite") {
     }
 
     "announce that 88 specs ran with 0 failures" in {
-      result.futureValue._2.reverse.apply(1) shouldEqual "[info] 88 specs, 0 failures, 4 pending specs"
+      result.futureValue._2.reverse.apply(3) shouldEqual "[info] 88 specs, 0 failures, 4 pending specs"
     }
 
     "announce that the task was successful" in {

--- a/src/it/scala/com/joescii/sbtjs/OneFailOnePendingSpec.scala
+++ b/src/it/scala/com/joescii/sbtjs/OneFailOnePendingSpec.scala
@@ -12,7 +12,7 @@ class OneFailOnePendingSpec extends SbtJsTestSpec("oneFailOnePending") {
     }
 
     "announce that 2 specs ran with 1 failure" in {
-      result.futureValue._2.reverse.apply(2) shouldEqual "[info] 3 specs, 1 failure, 1 pending spec"
+      result.futureValue._2.reverse.apply(4) shouldEqual "[info] 3 specs, 1 failure, 1 pending spec"
     }
 
     "announce that the task was unsuccessful" in {

--- a/src/it/scala/com/joescii/sbtjs/RequireJsSpec.scala
+++ b/src/it/scala/com/joescii/sbtjs/RequireJsSpec.scala
@@ -9,7 +9,7 @@ class RequireJsSpec extends SbtJsTestSpec("requireJs") {
     }
 
     "announce that 2 specs ran with 1 failure" in {
-      result.futureValue._2.reverse.apply(2) shouldEqual "[info] 2 specs, 1 failure"
+      result.futureValue._2.reverse.apply(4) shouldEqual "[info] 2 specs, 1 failure"
     }
 
   }

--- a/src/it/scala/com/joescii/sbtjs/RequireJsTimeoutSpec.scala
+++ b/src/it/scala/com/joescii/sbtjs/RequireJsTimeoutSpec.scala
@@ -9,7 +9,7 @@ class RequireJsTimeoutSpec extends SbtJsTestSpec("requireJsTimeout") {
     }
 
     "announce that 2 specs ran with 1 failure" in {
-      result.futureValue._2.reverse.apply(2) shouldEqual "[info] 2 specs, 1 failure"
+      result.futureValue._2.reverse.apply(4) shouldEqual "[info] 2 specs, 1 failure"
     }
 
   }

--- a/src/it/scala/com/joescii/sbtjs/TestOnlySpec.scala
+++ b/src/it/scala/com/joescii/sbtjs/TestOnlySpec.scala
@@ -8,7 +8,7 @@ class TestOnlySpec extends SbtJsTestSpec("testOnly") {
     }
 
     "announce that 1 spec ran with 0 failures" in {
-      result.futureValue._2.reverse.apply(1) shouldEqual "[info] 1 spec, 0 failures"
+      result.futureValue._2.reverse.apply(3) shouldEqual "[info] 1 spec, 0 failures"
     }
 
     "announce that the task was successful" in {
@@ -21,7 +21,7 @@ class TestOnlySpec extends SbtJsTestSpec("testOnly") {
     }
 
     "announce that 1 spec ran with 1 failure" in {
-      result.futureValue._2.reverse.apply(2) shouldEqual "[info] 1 spec, 1 failure"
+      result.futureValue._2.reverse.apply(3) shouldEqual "[info] 1 spec, 1 failure"
     }
 
     "announce that the task was unsuccessful" in {

--- a/src/it/scala/com/joescii/sbtjs/package.scala
+++ b/src/it/scala/com/joescii/sbtjs/package.scala
@@ -22,7 +22,7 @@ package object sbtjs {
     def /(child:String):String = s + slash + child
   }
 
-  class SbtJsTestSpec(project:String) extends WordSpec with ShouldMatchers with ScalaFutures {
+  class SbtJsTestSpec(project:String) extends WordSpec with Matchers with ScalaFutures {
     import build.BuildInfo._
 
     implicit val defaultPatience = PatienceConfig(timeout = Span(45, Seconds), interval = Span(500, Millis))

--- a/src/main/scala/com/joescii/sbtjs/SbtJsTestPlugin.scala
+++ b/src/main/scala/com/joescii/sbtjs/SbtJsTestPlugin.scala
@@ -27,26 +27,30 @@ object SbtJsTestPlugin extends AutoPlugin with SbtJsTestKeys {
   override def trigger = allRequirements
   override lazy val projectSettings = sbtJsTestSettings
 
+  val mainSrc = (sourceDirectory in Compile)
+  val rsrc = (unmanagedResourceDirectories in Compile)
+  val testSrc = (sourceDirectory in Test)
+  val rsrcTest = (unmanagedResourceDirectories in Test)
   lazy val sbtJsTestSettings:Seq[Def.Setting[_]] = List(
-    jsResources <<= (sourceDirectory in Compile, unmanagedResourceDirectories in Compile) { (main, rsrc) =>
-      ((main / "js") +: (main / "javascript") +: rsrc).flatMap(r => (r ** "*.js").get)
+    jsResources := {
+      ((mainSrc.value / "js") +: (mainSrc.value / "javascript") +: rsrc.value).flatMap(r => (r ** "*.js").get)
     },
-    watchSources <++= jsResources.map(identity),
+    watchSources ++= jsResources.map(identity).value,
 
-    jsTestResources <<= (sourceDirectory in Test, unmanagedResourceDirectories in Test) { (test, rsrc) =>
-      ((test / "js") +: (test / "javascript") +: rsrc).flatMap(r => (r ** "*.js").get)
+    jsTestResources := {
+      ((testSrc.value / "js") +: (testSrc.value / "javascript") +: rsrcTest.value).flatMap(r => (r ** "*.js").get)
     },
-    watchSources <++= jsTestResources.map(identity),
+    watchSources ++= jsTestResources.map(identity).value,
 
     jsTestColor := true,
     jsTestBrowsers := Seq(autoImport.JsTestBrowsers.Chrome),
     jsFrameworks := Seq(autoImport.JsTestFrameworks.Jasmine2),
-    jsTestTargetDir <<= (target in Test) (_ / "sbt-js-test"),
+    jsTestTargetDir := ((target in Test) (_ / "sbt-js-test")).value,
     jsAsyncWait := false,
     jsAsyncWaitTimeout := None,
 
-    jsTest <<= jsTestTask,
-    jsTestOnly <<= jsTestOnlyTask,
-    jsLs <<= jsLsTask
+    jsTest := jsTestTask.value,
+    jsTestOnly := jsTestOnlyTask.evaluated,
+    jsLs := jsLsTask.value
   )
 }

--- a/test-projects/project/build.properties
+++ b/test-projects/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=1.2.8

--- a/test-projects/project/plugins.sbt
+++ b/test-projects/project/plugins.sbt
@@ -1,6 +1,6 @@
 //resolvers += "Local Maven Repository" at Path.userHome.asFile.toURI.toURL + ".m2/repository"
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M12")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M13-4")
 
 libraryDependencies ++= Seq(
   "net.sourceforge.htmlunit"  % "htmlunit"             % "2.19"       % "runtime",

--- a/test-projects/project/project/plugins.sbt
+++ b/test-projects/project/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M12")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M13-4")


### PR DESCRIPTION
  - Updates to support sbt 1.0
  - Changes to dependant plugins and libraries for sbt 1.0

Notes:
There seemed to be some changes in the output from the javascript runners which changes the lines that were investigated in most of the tests. I fixed this by changing what lines were looked at, as I couldn't figure out what was causing the extra output.